### PR TITLE
Publicación automática de entregables (PDF) en GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 pdf/
 *.fuse*
 /.vagrant
+/_dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,11 @@ deploy:
   provider: releases
   api_key:
     secure: GBKwal1uUx8BF+IQuBN0Dut9mBfR0nKN36Kr4l4NiJr0JunGaFWXiX+jtc+HwGVRQ4sF2Yj37VccbDEkTEbFiIfLNvr6gb1q1kpCFSrw9oSq4K7vVdEfNQXzTL9zouFyjh6zaA3XyvK1GSfSEeLbX3hOBqJSlk+SFhJMd563lGoxdvuoHpWYUysvk3di4KfiNsvJcNRh5rry+fOMHZ6bronRIYY1M5tbe8UnCzlR33WGONKmzdUYJ8IM6n7Hte61KOhqx5Fl0CHxBI63y0rvRTtF6oGAlk0pyTB2+ZvS3I84Tzt1XHaJ0SN4O+fJMVUVPrGY4WU+41hWLgZXUNvvvGAgeNJKCJY0P6KAcJLtPmFDXKl/RtEyQLAQENl6bwBvWOY+HhQ4HY52YkvH9lIvg5IlzFRONpSvMKiD6qaFOhalGVR26snH+8jucxS3EG41Qx9e4D8pn55a764XO1+i/WRiP8ZEw6tCtHEvYkDN0HzQeEfmi7Ka32Vz336RrpS9EsQ+drStTUTrTu+f9ntTIHf0jVZgaTh/DcBkYW13EpQJjFPVc+cuIA6TlfGCxkUorWUqsxzjxzbTJHTKeR8/075Ovpad8hwo9JvFG8erDxmHgsHtphMGGuF0O36LHytBUogWWsO2aYuv4+tvlVF+nxnRlDnyBx5VNYzMdUxXxSA=
+  before_deploy:
+    - travis/prepare_release.sh
   file_glob: true
-  file: pdf/**/*.pdf
+  file:
+    - dist/*.pdf
   skip_cleanup: true
   on:
     repo: unlp-so/contenidos

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ before_install:
 script:
 - make
 
-  # Seccion de deployment generada mediante `travis setup releases`
+# Seccion de deployment generada mediante `travis setup releases`
+before_deploy:
+  - travis/prepare_release.sh
 deploy:
   provider: releases
   api_key:
     secure: GBKwal1uUx8BF+IQuBN0Dut9mBfR0nKN36Kr4l4NiJr0JunGaFWXiX+jtc+HwGVRQ4sF2Yj37VccbDEkTEbFiIfLNvr6gb1q1kpCFSrw9oSq4K7vVdEfNQXzTL9zouFyjh6zaA3XyvK1GSfSEeLbX3hOBqJSlk+SFhJMd563lGoxdvuoHpWYUysvk3di4KfiNsvJcNRh5rry+fOMHZ6bronRIYY1M5tbe8UnCzlR33WGONKmzdUYJ8IM6n7Hte61KOhqx5Fl0CHxBI63y0rvRTtF6oGAlk0pyTB2+ZvS3I84Tzt1XHaJ0SN4O+fJMVUVPrGY4WU+41hWLgZXUNvvvGAgeNJKCJY0P6KAcJLtPmFDXKl/RtEyQLAQENl6bwBvWOY+HhQ4HY52YkvH9lIvg5IlzFRONpSvMKiD6qaFOhalGVR26snH+8jucxS3EG41Qx9e4D8pn55a764XO1+i/WRiP8ZEw6tCtHEvYkDN0HzQeEfmi7Ka32Vz336RrpS9EsQ+drStTUTrTu+f9ntTIHf0jVZgaTh/DcBkYW13EpQJjFPVc+cuIA6TlfGCxkUorWUqsxzjxzbTJHTKeR8/075Ovpad8hwo9JvFG8erDxmHgsHtphMGGuF0O36LHytBUogWWsO2aYuv4+tvlVF+nxnRlDnyBx5VNYzMdUxXxSA=
-  before_deploy:
-    - travis/prepare_release.sh
   file_glob: true
   file:
     - dist/*.pdf

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ deploy:
     secure: GBKwal1uUx8BF+IQuBN0Dut9mBfR0nKN36Kr4l4NiJr0JunGaFWXiX+jtc+HwGVRQ4sF2Yj37VccbDEkTEbFiIfLNvr6gb1q1kpCFSrw9oSq4K7vVdEfNQXzTL9zouFyjh6zaA3XyvK1GSfSEeLbX3hOBqJSlk+SFhJMd563lGoxdvuoHpWYUysvk3di4KfiNsvJcNRh5rry+fOMHZ6bronRIYY1M5tbe8UnCzlR33WGONKmzdUYJ8IM6n7Hte61KOhqx5Fl0CHxBI63y0rvRTtF6oGAlk0pyTB2+ZvS3I84Tzt1XHaJ0SN4O+fJMVUVPrGY4WU+41hWLgZXUNvvvGAgeNJKCJY0P6KAcJLtPmFDXKl/RtEyQLAQENl6bwBvWOY+HhQ4HY52YkvH9lIvg5IlzFRONpSvMKiD6qaFOhalGVR26snH+8jucxS3EG41Qx9e4D8pn55a764XO1+i/WRiP8ZEw6tCtHEvYkDN0HzQeEfmi7Ka32Vz336RrpS9EsQ+drStTUTrTu+f9ntTIHf0jVZgaTh/DcBkYW13EpQJjFPVc+cuIA6TlfGCxkUorWUqsxzjxzbTJHTKeR8/075Ovpad8hwo9JvFG8erDxmHgsHtphMGGuF0O36LHytBUogWWsO2aYuv4+tvlVF+nxnRlDnyBx5VNYzMdUxXxSA=
   file_glob: true
   file:
-    - dist/*.pdf
+    - _dist/*.pdf
   skip_cleanup: true
   on:
     repo: unlp-so/contenidos

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,20 @@
 sudo: required
 dist: trusty
 before_install:
-  - sudo apt-get -qq update && sudo apt-get install -y texlive texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended texlive-lang-spanish build-essential
+- sudo apt-get -qq update && sudo apt-get install -y texlive texlive-fonts-recommended
+  texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended texlive-lang-spanish
+  build-essential
 script:
-  - make
-#deploy:
-#  provider: releases
-#  api_key:
-#    secure: [YOUR KEY]
-#  file:
-#    - _build/your_file_1.pdf
-#  skip_cleanup: true
-#  on:
-#    tags: true
+- make
 
+  # Seccion de deployment generada mediante `travis setup releases`
+deploy:
+  provider: releases
+  api_key:
+    secure: GBKwal1uUx8BF+IQuBN0Dut9mBfR0nKN36Kr4l4NiJr0JunGaFWXiX+jtc+HwGVRQ4sF2Yj37VccbDEkTEbFiIfLNvr6gb1q1kpCFSrw9oSq4K7vVdEfNQXzTL9zouFyjh6zaA3XyvK1GSfSEeLbX3hOBqJSlk+SFhJMd563lGoxdvuoHpWYUysvk3di4KfiNsvJcNRh5rry+fOMHZ6bronRIYY1M5tbe8UnCzlR33WGONKmzdUYJ8IM6n7Hte61KOhqx5Fl0CHxBI63y0rvRTtF6oGAlk0pyTB2+ZvS3I84Tzt1XHaJ0SN4O+fJMVUVPrGY4WU+41hWLgZXUNvvvGAgeNJKCJY0P6KAcJLtPmFDXKl/RtEyQLAQENl6bwBvWOY+HhQ4HY52YkvH9lIvg5IlzFRONpSvMKiD6qaFOhalGVR26snH+8jucxS3EG41Qx9e4D8pn55a764XO1+i/WRiP8ZEw6tCtHEvYkDN0HzQeEfmi7Ka32Vz336RrpS9EsQ+drStTUTrTu+f9ntTIHf0jVZgaTh/DcBkYW13EpQJjFPVc+cuIA6TlfGCxkUorWUqsxzjxzbTJHTKeR8/075Ovpad8hwo9JvFG8erDxmHgsHtphMGGuF0O36LHytBUogWWsO2aYuv4+tvlVF+nxnRlDnyBx5VNYzMdUxXxSA=
+  file_glob: true
+  file: pdf/**/*.pdf
+  skip_cleanup: true
+  on:
+    repo: unlp-so/contenidos
+    tags: true

--- a/README.md
+++ b/README.md
@@ -89,16 +89,16 @@ nueva _release_ del repositorio. Para una mejor organización de los materiales 
 futuro, se recomienda seguir la siguiente estructura en los nombres de los tags:
 
 ```
-YYYY-mm-vv
+YYYY-mm-vvv
 ```
 
 Donde:
 
 * `YYYY` es el número de año expresado con cuatro dígitos (por ejemplo: `2017`).
 * `mm` es el número de mes expresado con dos dígitos (por ejemplo: `08`).
-* `vv` es un número de versión incremental por mes expresado con dos dígitos, es
-  decir que con cada cambio de año/mes se vuelve a iniciar desde la versión 0
-  (por ejemplo: `00`).
+* `vvv` es un número de versión incremental por mes expresado con tres dígitos,
+  es decir que con cada cambio de año/mes se vuelve a iniciar desde la versión 0
+  (por ejemplo: `000`).
 
 De esta forma, tendremos una organización cronológica de los cambios que se
 realicen, y podremos saber fácilmente qué versión es la última para un año y/o

--- a/README.md
+++ b/README.md
@@ -74,3 +74,32 @@ directorio `pdf/`. ¡No hagas `commit`s de PDFs sin terminar!
 La mejor forma de escribir material para la cátedra utilizando este
 repositorio es mirando y estudiando lo que ya está hecho, con el objetivo de
 aprender la sintaxis, y traducir a LaTeX el material de años anteriores.
+
+# Publicación de los materiales
+
+Este repositorio utiliza [Travis CI](https://travis-ci.org) como herramienta de
+integración contínua. Esto nos permite no sólo asegurarnos que los cambios que
+realizamos a los fuentes LaTeX no generan errores, sino que además nos permite
+generar automáticamente los entregables en formato PDF y publicarlos dentro de
+las _releases_ de GitHub.
+
+Para publicar una nueva versión del material, basta con crear un tag de git, y
+Travis CI se encargará de generar los PDF por nosotros y publicarlos como una
+nueva _release_ del repositorio. Para una mejor organización de los materiales a
+futuro, se recomienda seguir la siguiente estructura en los nombres de los tags:
+
+```
+YYYY-mm-vv
+```
+
+Donde:
+
+* `YYYY` es el número de año expresado con cuatro dígitos (por ejemplo: `2017`).
+* `mm` es el número de mes expresado con dos dígitos (por ejemplo: `08`).
+* `vv` es un número de versión incremental por mes expresado con dos dígitos, es
+  decir que con cada cambio de año/mes se vuelve a iniciar desde la versión 0
+  (por ejemplo: `00`).
+
+De esta forma, tendremos una organización cronológica de los cambios que se
+realicen, y podremos saber fácilmente qué versión es la última para un año y/o
+semestre particular, si así lo requiriésemos.

--- a/travis/prepare_release.sh
+++ b/travis/prepare_release.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Este script prepara los archivos generados para que puedan ser publicados como una release en GitHub sin sobreescribir los nombres de archivo.
+
+set -eo pipefail
+
+DEST="_dist"
+
+mkdir -p "${DEST}"
+
+for subject in iso so; do
+  for dir in $(find pdf -name "${subject}" -type d); do
+    for file in $(find $dir -name '*.pdf'); do
+      group="$(dirname "${file}")"
+      group=${group##pdf/}
+      group="${group%%/*}"
+      target="${subject}_${group}_$(basename "${file}")"
+      cp "${file}" "${DEST}/${target}"
+    done
+  done
+done

--- a/travis/prepare_release.sh
+++ b/travis/prepare_release.sh
@@ -4,6 +4,8 @@
 
 set -eo pipefail
 
+echo "Preparando archivos PDF generados para publicarlos como una nueva release"
+
 DEST="_dist"
 
 mkdir -p "${DEST}"
@@ -16,6 +18,7 @@ for subject in iso so; do
       group="${group%%/*}"
       target="${subject}_${group}_$(basename "${file}")"
       cp "${file}" "${DEST}/${target}"
+      echo "- Copiado '${file}' a '${DEST}/${target}'"
     done
   done
 done


### PR DESCRIPTION
Este Pull Request agrega la posibilidad de generar automáticamente los PDFs y publicarlos como una _release_ en GitHub, de manera que se puedan descargar desde cualquier lugar y en todo momento, la última versión "estable" de los contenidos del repositorio.

El funcionamiento de esto es simple: subimos (`git push`) nuestro código como siempre, y cuando queremos que se publique una nueva _release_ de los PDFs con los últimos cambios realizados, generamos un tag de git (`git tag <nombre del tag>` y luego `git push --tags`). Esto dispara una tarea de Travis que, de estar todo bien, generará los PDF y los publicará como un release con el nombre del tag que acabamos de crear.

A partir de esto, propongo un esquema de nombres para los tags, de manera que no se nos desmadren luego los releases:

```
YYYY-mm-vvv
```

Donde:

* `YYYY` es el número de año expresado con cuatro dígitos (por ejemplo: `2017`).
* `mm` es el número de mes expresado con dos dígitos (por ejemplo: `08`).
* `vvv` es un número de versión incremental por mes expresado con tres dígitos, es decir que con cada cambio de año/mes se vuelve a iniciar desde la versión 0 (por ejemplo: `001`).

Pueden ver [en las _releases_ del repositorio en GitHub](https://github.com/unlp-so/contenidos/releases) un ejemplo de cómo quedan.

> _Esto está explicado en el [README de esta rama](https://github.com/unlp-so/contenidos/blob/travis-releases/README.md#publicación-de-los-materiales) para que lo tengamos de referencia, de ser necesario._
